### PR TITLE
Remove menu reset by defualt as reset can be passed via onNodeClick

### DIFF
--- a/src/lib/mlpushmenu.js
+++ b/src/lib/mlpushmenu.js
@@ -164,18 +164,6 @@ module.exports = (function (window) {
 			});
 
 			// closing the sub levels :
-			// by clicking on the visible part of the level element
-			this.levels.forEach(function (el, i) {
-				el.addEventListener(self.eventtype, function (ev) {
-					var level = el.getAttribute('data-level');
-					if (self.level > level) {
-						// ev.stopPropagation();
-						self.level = level;
-						self._closeMenu();
-					}
-				});
-			});
-
 			// by clicking on a specific element
 			this.levelBack.forEach(function (el, i) {
 				el.addEventListener(self.eventtype, function (ev) {


### PR DESCRIPTION
Hi, I really like this package however I find it won't meet my needs for essentially one reason: I'm unable to to prevent the menu close when clicking node names. And, due to this click event being added via an anonymous function, I am also not sure it can be removed. Can this functionality simply be passed via the onNodeClick prop if it is desired?